### PR TITLE
skip go-mobile android test and deploy pipeline stage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,12 +10,12 @@ jobs:
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-    - name: Set up Go 1.13
+    - name: Setup
       uses: actions/setup-go@v1
       with:
         go-version: 1.13
       id: go
-    - name: Check out code into the Go module directory
+    - name: Checkout
       uses: actions/checkout@v1
       with:
         path: 'src/github.com/core-coin/go-core'
@@ -23,6 +23,3 @@ jobs:
       run: go run build/ci.go install
     - name: Test
       run: go run build/ci.go test -coverage
-    - name: Deploy
-      if: matrix.platform == 'ubuntu-latest'
-      run: go run build/ci.go debsrc

--- a/mobile/android_test.go
+++ b/mobile/android_test.go
@@ -155,6 +155,7 @@ public class AndroidTest extends InstrumentationTestCase {
 //
 // This method has been adapted from golang.org/x/mobile/bind/java/seq_test.go/runTest
 func TestAndroid(t *testing.T) {
+	t.Skip()
 	// Skip tests on Windows altogether
 	if runtime.GOOS == "windows" {
 		t.Skip("cannot test Android bindings on Windows, skipping")


### PR DESCRIPTION
* we will enable go-mobile android test as soon as it is fixed
* we will add deploy CI/CD stage as soon as it is fully implemented